### PR TITLE
Add static Terraform checks workflow and update README.md

### DIFF
--- a/.github/workflows/infra-static-tests.yml
+++ b/.github/workflows/infra-static-tests.yml
@@ -1,0 +1,37 @@
+name: Static Terraform Checks
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  static-analysis:
+    name: Static Analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.7
+
+      - name: Terraform Format Check
+        working-directory: infra/tf-app
+        run: terraform fmt -check -recursive
+
+      - name: Install tflint
+        run: |
+          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+
+      - name: Run tflint
+        working-directory: infra/tf-app
+        run: tflint --recursive
+
+        

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The infrastructure code is defined in Terraform and stored in the `infra` folder
 
 ---
 
-## 👥 Team Members
+##  Team Members
 
 | Name             | GitHub Username        | Responsibilities                          |
 |------------------|------------------------|--------------------------------------------|
@@ -16,7 +16,7 @@ The infrastructure code is defined in Terraform and stored in the `infra` folder
 
 ---
 
-## 📁 Folder Structure
+##  Folder Structure
 
 ```
 cst8918-w25-lab12
@@ -36,7 +36,7 @@ cst8918-w25-lab12
 
 ---
 
-## 🔐 Terraform Remote State
+##  Terraform Remote State
 
 Terraform state is stored remotely in an Azure Storage Account:
 
@@ -46,7 +46,7 @@ Terraform state is stored remotely in an Azure Storage Account:
 
 ---
 
-## ✅ Screenshots (Required for Submission)
+##  Screenshots (Required for Submission)
 
 | Description          | Screenshot Path                    |
 |----------------------|-------------------------------------|
@@ -55,8 +55,40 @@ Terraform state is stored remotely in an Azure Storage Account:
 
 ---
 
-## 📋 Notes
+## Notes
 
 - Application code is not included — focus is on infrastructure and automation.
 - CI/CD includes static testing, integration testing, deploy, and drift detection.
 - Uses GitHub OIDC for secure Azure login from workflows.
+
+## GitHub Actions Workflow: Static Terraform Checks
+A CI workflow was added at .github/workflows/infra-static-tests.yml to run Terraform static analysis on each push to the dev branch and on pull requests to main.
+
+### What This Workflow Does
+This workflow performs two types of static checks:
+
+### terraform fmt
+Verifies that all .tf files are properly formatted using the standard Terraform style.
+
+### tflint
+Lints the Terraform code for common issues, best practices, and style problems.
+
+##  Trigger Conditions
+This workflow runs automatically when:
+
+A developer pushes to the dev branch
+
+A pull request is opened targeting the main branch
+
+## Successful Workflow Execution
+After pushing the workflow file and opening a PR from dev to main, the GitHub Actions pipeline was triggered and completed successfully.
+
+- Screenshot 1: All checks passed
+
+- Screenshot 2: Static Terraform Check Output
+
+### These checks ensure that:
+
+- The Terraform code is clean and consistent
+
+- The CI system is working before applying real infrastructure changes

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The infrastructure code is defined in Terraform and stored in the `infra` folder
 | Name             | GitHub Username        | Responsibilities                          |
 |------------------|------------------------|--------------------------------------------|
 | Maryam Khalaf    | MaryamKhalaf2010       | Repo setup, remote backend configuration   |
-| Member B         | usernameB              | AKS infrastructure                        |
+| Rahaf Alkhlaf    | alkh0115               | AKS infrastructure                        |
 | Member C         | usernameC              | GitHub Actions CI/CD                      |
 
 ---

--- a/infra/tf-app/main.tf
+++ b/infra/tf-app/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.75.0"
+    }
+  }
+
+  required_version = ">= 1.5.0"
+}


### PR DESCRIPTION
A CI workflow was added at .github/workflows/infra-static-tests.yml to run Terraform static analysis on each push to the dev branch and on pull requests to main.